### PR TITLE
Build and release using Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+language: minimal
+dist: xenial
+
+addons:
+  apt:
+    packages:
+      - docker.io
+      # Travis uses --no-install-suggests and --no-install-recommends so all necessary packages must be explicitly installed
+      - lazarus
+      - lcl
+
+script:
+  # Without -q -q the build logs exceed the amount Travis will show in the web interface (10k lines)
+  - lazbuild -q -q --cpu=x86_64 Source/LdapAdmin.lpi
+  - tar -cvzf LdapAdmin-linux-64bit.tar.gz -C Source LdapAdmin
+  - |
+    docker build -t lazbuild -<<EOF
+    FROM i386/ubuntu:xenial
+    RUN apt update
+    RUN apt install -y --no-install-suggests --no-install-recommends lazarus lcl
+    EOF
+  - docker run -it --rm -v $(pwd)/Source:/Source lazbuild lazbuild -q -q --cpu=i386 /Source/LdapAdmin.lpi
+  - tar -cvzf LdapAdmin-linux-32bit.tar.gz -C Source LdapAdmin
+
+deploy:
+  provider: releases
+  api_key: $GITHUB_OAUTH_TOKEN
+  file:
+    - LdapAdmin-linux-32bit.tar.gz
+    - LdapAdmin-linux-64bit.tar.gz
+  skip_cleanup: true
+  on:
+    tags: true

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Disabled functions:
 - Scripting
 
 
+## Downloads
+See [releases](../../releases)
+
+
 ## Requirements
 - Lazarus 1.6.2+, developed on version 1.8.4
 - compiler FPC 3.0.0+, developed on version 3.0.4


### PR DESCRIPTION
I'm not sure if this interests you or not, but I set up automated builds and releases (32 and 64-bit) using Travis. To add this you'd just need to create a free account on travis.org and set `GITHUB_OAUTH_TOKEN` in Travis with a Github auth token that has `repo` permissions (https://docs.travis-ci.com/user/deployment/releases#authenticating-with-an-oauth-token). Any time you push a tag, Travis will automatically create a release for you and upload the latest builds. You can see what it looks like here: https://github.com/bmaupin/LDAP-Admin/releases

I also added a workaround for #3.

Thanks!